### PR TITLE
Fix region dropdown issue

### DIFF
--- a/src/main/java/com/amazonaws/jenkins/plugins/sam/util/BeanHelper.java
+++ b/src/main/java/com/amazonaws/jenkins/plugins/sam/util/BeanHelper.java
@@ -9,6 +9,9 @@ import com.amazonaws.regions.Regions;
 
 import hudson.util.ListBoxModel;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 /**
  * @author Trek10, Inc.
  */
@@ -17,10 +20,16 @@ public class BeanHelper {
     public static ListBoxModel doFillRegionItems() {
         ListBoxModel list = new ListBoxModel();
         for (Region region : RegionUtils.getRegions()) {
-            Regions regionData = Regions.fromName(region.getName());
-            list.add(regionData.getDescription(), regionData.getName());
+            String regionName = region.getName();
+            try {
+                Regions regionData = Regions.fromName(regionName);
+                list.add(regionData.getDescription(), regionData.getName());
+            } catch(Exception e) {
+                LOGGER.log(Level.INFO, "Failed to enumerate AWS region '" + regionName + "'", e);
+            }
         }
         return list;
     }
 
+    private static final Logger LOGGER = Logger.getLogger(BeanHelper.class.getName());
 }

--- a/src/test/java/com/amazonaws/jenkins/plugins/sam/export/ArtifactUploaderTest.java
+++ b/src/test/java/com/amazonaws/jenkins/plugins/sam/export/ArtifactUploaderTest.java
@@ -60,33 +60,33 @@ public class ArtifactUploaderTest {
     @Test
     public void testUploadObjectExists() {
         String result = uploader.upload(artifactFilePath);
-        assertEquals(result, "s3://some-bucket/test-prefix/6b700b9cfefe0b9f6666a0882ee004ab");
+        assertEquals(result, "s3://some-bucket/test-prefix/42637f683b13b9beec74eab6d2a442cd");
         verify(s3Client, times(0)).putObject(any(PutObjectRequest.class));
     }
 
     @Test
     public void testUploadObjectDoesNotExist() {
-        when(s3Client.getObjectMetadata("some-bucket", "test-prefix/6b700b9cfefe0b9f6666a0882ee004ab"))
+        when(s3Client.getObjectMetadata("some-bucket", "test-prefix/42637f683b13b9beec74eab6d2a442cd"))
                 .thenThrow(new AmazonS3Exception("error"));
         String result = uploader.upload(artifactFilePath);
-        assertEquals(result, "s3://some-bucket/test-prefix/6b700b9cfefe0b9f6666a0882ee004ab");
+        assertEquals(result, "s3://some-bucket/test-prefix/42637f683b13b9beec74eab6d2a442cd");
         verify(s3Client, times(1)).putObject(putObjectRequestCaptor.capture());
         PutObjectRequest request = putObjectRequestCaptor.getValue();
         assertEquals(request.getBucketName(), "some-bucket");
-        assertEquals(request.getKey(), "test-prefix/6b700b9cfefe0b9f6666a0882ee004ab");
-        assertEquals(request.getMetadata().getContentLength(), 91);
+        assertEquals(request.getKey(), "test-prefix/42637f683b13b9beec74eab6d2a442cd");
+        assertEquals(request.getMetadata().getContentLength(), 89);
         assertEquals(request.getMetadata().getSSEAlgorithm(), "AES256");
     }
 
     @Test
     public void testUploadObjectWithExtensionAndKms() {
-        when(s3Client.getObjectMetadata("some-bucket", "6b700b9cfefe0b9f6666a0882ee004ab.js"))
+        when(s3Client.getObjectMetadata("some-bucket", "42637f683b13b9beec74eab6d2a442cd.js"))
                 .thenThrow(new AmazonS3Exception("error"));
         config.setS3Prefix(null);
         config.setKmsKeyId("some-kms");
         uploader = ArtifactUploader.build(s3Client, config, logger);
         String result = uploader.upload(artifactFilePath, "js");
-        assertEquals(result, "s3://some-bucket/6b700b9cfefe0b9f6666a0882ee004ab.js");
+        assertEquals(result, "s3://some-bucket/42637f683b13b9beec74eab6d2a442cd.js");
         verify(s3Client, times(1)).putObject(putObjectRequestCaptor.capture());
         PutObjectRequest request = putObjectRequestCaptor.getValue();
         assertEquals(request.getSSEAwsKeyManagementParams().getAwsKmsKeyId(), "some-kms");

--- a/src/test/java/com/amazonaws/jenkins/plugins/sam/export/ArtifactUploaderTest.java
+++ b/src/test/java/com/amazonaws/jenkins/plugins/sam/export/ArtifactUploaderTest.java
@@ -60,33 +60,33 @@ public class ArtifactUploaderTest {
     @Test
     public void testUploadObjectExists() {
         String result = uploader.upload(artifactFilePath);
-        assertEquals(result, "s3://some-bucket/test-prefix/42637f683b13b9beec74eab6d2a442cd");
+        assertEquals(result, "s3://some-bucket/test-prefix/6b700b9cfefe0b9f6666a0882ee004ab");
         verify(s3Client, times(0)).putObject(any(PutObjectRequest.class));
     }
 
     @Test
     public void testUploadObjectDoesNotExist() {
-        when(s3Client.getObjectMetadata("some-bucket", "test-prefix/42637f683b13b9beec74eab6d2a442cd"))
+        when(s3Client.getObjectMetadata("some-bucket", "test-prefix/6b700b9cfefe0b9f6666a0882ee004ab"))
                 .thenThrow(new AmazonS3Exception("error"));
         String result = uploader.upload(artifactFilePath);
-        assertEquals(result, "s3://some-bucket/test-prefix/42637f683b13b9beec74eab6d2a442cd");
+        assertEquals(result, "s3://some-bucket/test-prefix/6b700b9cfefe0b9f6666a0882ee004ab");
         verify(s3Client, times(1)).putObject(putObjectRequestCaptor.capture());
         PutObjectRequest request = putObjectRequestCaptor.getValue();
         assertEquals(request.getBucketName(), "some-bucket");
-        assertEquals(request.getKey(), "test-prefix/42637f683b13b9beec74eab6d2a442cd");
-        assertEquals(request.getMetadata().getContentLength(), 89);
+        assertEquals(request.getKey(), "test-prefix/6b700b9cfefe0b9f6666a0882ee004ab");
+        assertEquals(request.getMetadata().getContentLength(), 91);
         assertEquals(request.getMetadata().getSSEAlgorithm(), "AES256");
     }
 
     @Test
     public void testUploadObjectWithExtensionAndKms() {
-        when(s3Client.getObjectMetadata("some-bucket", "42637f683b13b9beec74eab6d2a442cd.js"))
+        when(s3Client.getObjectMetadata("some-bucket", "6b700b9cfefe0b9f6666a0882ee004ab.js"))
                 .thenThrow(new AmazonS3Exception("error"));
         config.setS3Prefix(null);
         config.setKmsKeyId("some-kms");
         uploader = ArtifactUploader.build(s3Client, config, logger);
         String result = uploader.upload(artifactFilePath, "js");
-        assertEquals(result, "s3://some-bucket/42637f683b13b9beec74eab6d2a442cd.js");
+        assertEquals(result, "s3://some-bucket/6b700b9cfefe0b9f6666a0882ee004ab.js");
         verify(s3Client, times(1)).putObject(putObjectRequestCaptor.capture());
         PutObjectRequest request = putObjectRequestCaptor.getValue();
         assertEquals(request.getSSEAwsKeyManagementParams().getAwsKmsKeyId(), "some-kms");


### PR DESCRIPTION
This fixes the issue that has been reported and verified where the settings dropdown for the AWS region does not populate.

The issue is documented in both #8 and #10.

This fix basically catches the exception when trying to enumerate an unsupported region, and logs it as an INFO message.