### PR TITLE
[maven-release-plugin] prepare release aws-sam-1.2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 			<url>https://opensource.org/licenses/MIT</url>
 		</license>
 	</licenses>
-	<url>https://wiki.jenkins.io/display/JENKINS/AWS+SAM+Plugin</url>
+	<url>https://github.com/jenkinsci/aws-sam-plugin</url>
 	<scm>
 		<connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
 		<developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 	</parent>
 	<groupId>io.jenkins.plugins</groupId>
 	<artifactId>aws-sam</artifactId>
-	<version>1.2.4-SNAPSHOT</version>
+	<version>1.2.4</version>
 	<packaging>hpi</packaging>
 	<properties>
 		<jenkins.version>2.7.3</jenkins.version>
@@ -31,7 +31,7 @@
 		<connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
 		<developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
 		<url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-	  <tag>aws-sam-1.2.1</tag>
+	  <tag>aws-sam-1.2.4</tag>
   </scm>
 	<organization>
 		<name>Trek10, Inc.</name>


### PR DESCRIPTION
- Update `url` so the plugin page syncs with the GitHub README (see https://www.jenkins.io/doc/developer/publishing/documentation/)
- Bump version and point to new tag (will point to this after merge)

Previous commits for inspiration: https://github.com/jenkinsci/aws-sam-plugin/commit/f834bb116516e853dc1e44c8d40ecd77bf225ce5 https://github.com/jenkinsci/aws-sam-plugin/commit/89b117cc525e1ed09d07f51998aeee47104389e4