### PR TITLE
Use Safe YAML instead of Snake YAML

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,10 +77,10 @@
 			<version>1.11.341</version>
 		</dependency>
 		<dependency>
-    		<groupId>io.jenkins.plugins</groupId>
-    		<artifactId>snakeyaml-api</artifactId>
-    		<version>1.30.1</version>
-  		</dependency>
+			<groupId>com.konloch</groupId>
+			<artifactId>safeyaml</artifactId>
+			<version>1.33.0</version>
+		</dependency>
 		<dependency>
 			<groupId>org.json</groupId>
 			<artifactId>json</artifactId>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
1. SnakeYAML 2.2 are used by default in suggested Jenkins plugins and some of the default plugins instead. This caused an issue for customers who are using Jenkins since Jenkins only allows one version of an existing dependency. The version 2.2 requires a different code syntax. So for users who want to use `aws-sam-plugin`, it fails at reading the template step. Use SafeYAML instead.


### Testing done
Local tests pass and CI passes.


```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
